### PR TITLE
Fix/smart report 엑셀 기반 관련 기능 수정 및 개선

### DIFF
--- a/src/main/java/com/found404/marketbee/crawl/CrawlController.java
+++ b/src/main/java/com/found404/marketbee/crawl/CrawlController.java
@@ -28,7 +28,6 @@ public class CrawlController {
             case SKIPPED:
                 return ResponseEntity.ok(Map.of("status", "SKIPPED", "message", result.getMessage()));
             case FAILED:
-                // 크롤링 중 오류가 발생한 경우 (서버 오류)
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                         .body(Map.of("status", "FAILED", "message", result.getMessage()));
             default:

--- a/src/main/java/com/found404/marketbee/crawl/CrawlService.java
+++ b/src/main/java/com/found404/marketbee/crawl/CrawlService.java
@@ -129,7 +129,6 @@ public class CrawlService {
                     pythonExecutable, scriptPath, storeUuid, placeName
             );
 
-            // 파이썬 한글 깨짐오류 방지
             processBuilder.environment().put("PYTHONIOENCODING", "UTF-8");
             processBuilder.redirectErrorStream(true);
 

--- a/src/main/java/com/found404/marketbee/reportSuggestion/service/ReportSuggestionGenerationService.java
+++ b/src/main/java/com/found404/marketbee/reportSuggestion/service/ReportSuggestionGenerationService.java
@@ -49,13 +49,11 @@ public class ReportSuggestionGenerationService {
 
             Map<String, Object> parsedSuggestions = parseCombinedGptResponse(gptResponse);
 
-            //매출 개선팁 저장
             List<String> improvementTips = getListFromParsedSuggestions(parsedSuggestions, "improvementTips", String.class);
             String tipsJson = objectMapper.writeValueAsString(improvementTips);
             monthlyStat.updateImprovementTips(tipsJson);
             monthlyStatRepository.save(monthlyStat);
 
-            //마케팅 제안 저장
             List<Map<String, String>> marketingSuggestionsData = getListOfMapsFromParsedSuggestions(parsedSuggestions, "marketingSuggestions");
 
             marketingSuggestionRepository.deleteByMonthlyStat(monthlyStat);
@@ -75,7 +73,6 @@ public class ReportSuggestionGenerationService {
         }
     }
 
-    //타입 변환을 위한 헬퍼 메소드
     private <T> List<T> getListFromParsedSuggestions(Map<String, Object> parsedSuggestions, String key, Class<T> elementType) {
         Object value = parsedSuggestions.get(key);
         if (value instanceof List) {
@@ -140,10 +137,11 @@ public class ReportSuggestionGenerationService {
         promptBuilder.append("1. 위 데이터를 바탕으로 현실적인 조언을 해주세요.\n");
         promptBuilder.append("2. 답변은 반드시 JSON 형식이어야 하며, 두 개의 키를 가져야 합니다: 'improvementTips'와 'marketingSuggestions'.\n");
         promptBuilder.append("3. 'improvementTips'의 값은, 위 데이터를 종합하여 매장 운영에 대한 핵심 개선팁 2개를 담은 JSON 문자열 배열**이어야 합니다. 각 팁은 반드시 **적당한 길이의 한 문장으로** 생성해주세요.\n");
-        promptBuilder.append("4. 'marketingSuggestions' 키의 값은 **JSON 객체들의 배열**이어야 하며, 정확히 8개의 창의적이고 실현 가능한 마케팅 제안을 포함해야 합니다.\n");
-        promptBuilder.append("5. 8개의 마케팅 제안은 **강점 활용 전략 최소 2개**와 **약점 보완 전략 최소 2개**를 반드시 골고루 포함해야 합니다.\n");
-        promptBuilder.append("5. 각 마케팅 제안 객체는 'title'(짧은 제목)과 'description'(구체적인 설명) 두 개의 키를 가져야 합니다.\n");
-        promptBuilder.append("6. 예시: {\"improvementTips\": [\"팁1 요약.\", \"팁2 요약.\"], \"marketingSuggestions\": [{\"title\": \"제목1\", \"description\": \"설명1\"}, ..., {\"title\": \"제목8\", \"description\": \"설명8\"}]}");
+        promptBuilder.append("4. 2개의 개선팁은 형식적인 답이 아닌 위 데이터의 내용(메뉴명, 시간대, 요일)을 100% 활용하여, 답변에 직간접적으로 사용해야 합니다.\n");
+        promptBuilder.append("5. 'marketingSuggestions' 키의 값은 **JSON 객체들의 배열**이어야 하며, 정확히 8개의 창의적이고 실현 가능한 마케팅 제안을 포함해야 합니다.\n");
+        promptBuilder.append("6. 8개의 마케팅 제안은 **강점 활용 전략 최소 2개**와 **약점 보완 전략 최소 2개**를 반드시 골고루 포함해야 합니다.\n");
+        promptBuilder.append("7. 각 마케팅 제안 객체는 'title'(짧은 제목)과 'description'(구체적인 설명) 두 개의 키를 가져야 합니다.\n");
+        promptBuilder.append("8. 예시: {\"improvementTips\": [\"팁1 요약.\", \"팁2 요약.\"], \"marketingSuggestions\": [{\"title\": \"제목1\", \"description\": \"설명1\"}, ..., {\"title\": \"제목8\", \"description\": \"설명8\"}]}");
 
         return promptBuilder.toString();
     }
@@ -162,14 +160,13 @@ public class ReportSuggestionGenerationService {
 
         String cleanedJson = content.trim();
 
-        //Markdown 코드 블록 기호 제거
         if (cleanedJson.startsWith("```json")) {
             cleanedJson = cleanedJson.substring(7);
             if (cleanedJson.endsWith("```")) {
                 cleanedJson = cleanedJson.substring(0, cleanedJson.length() - 3);
             }
         }
-        //일반 코드 블록 기호 제거
+
         if (cleanedJson.startsWith("```")) {
             cleanedJson = cleanedJson.substring(3);
             if (cleanedJson.endsWith("```")) {

--- a/src/main/java/com/found404/marketbee/salesRecord/entity/MonthlyStat.java
+++ b/src/main/java/com/found404/marketbee/salesRecord/entity/MonthlyStat.java
@@ -1,10 +1,14 @@
 package com.found404.marketbee.salesRecord.entity;
 
+import com.found404.marketbee.reportSuggestion.MarketingSuggestion;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,6 +38,9 @@ public class MonthlyStat {
 
     @Column(columnDefinition = "TEXT")
     private String improvementTipsJson;
+
+    @OneToMany(mappedBy = "monthlyStat", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MarketingSuggestion> marketingSuggestions = new ArrayList<>();
 
     @Builder
     public MonthlyStat(String storeUuid, String yearMonth) {

--- a/src/main/java/com/found404/marketbee/salesRecord/repository/MonthlyStatRepository.java
+++ b/src/main/java/com/found404/marketbee/salesRecord/repository/MonthlyStatRepository.java
@@ -2,15 +2,12 @@ package com.found404.marketbee.salesRecord.repository;
 
 import com.found404.marketbee.salesRecord.entity.MonthlyStat;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface MonthlyStatRepository extends JpaRepository<MonthlyStat, Long> {
     Optional<MonthlyStat> findByStoreUuidAndYearMonth(String storeUuid, String yearMonth);
 
-    @Modifying
-    @Query("DELETE FROM MonthlyStat m WHERE m.storeUuid = :storeUuid AND m.yearMonth < :cutoffYearMonth")
-    void deleteOldData(@Param("storeUuid") String storeUuid, @Param("cutoffYearMonth") String cutoffYearMonth);
+    List<MonthlyStat> findByStoreUuidAndYearMonthLessThan(String storeUuid, String cutoffYearMonth);
 }


### PR DESCRIPTION
1. 워스트 메뉴 선정 로직 수정
- 기존에는 매출 0원인 상품이 데이터 파싱 단계에서 제외되어 누락되었었음
- > 매출이 0원인 상품도 포함할 수 있도록 parseProductSalesSheet 메소드 수정

2. 개선팁 생성 AI 프롬프트 수정
- 기존 프롬프트는 데이터가 적으면 획일화된 답변만 얻을 수 있어, 개선팁의 질이 높지 않았음
- > 데이터를 더 구체적으로 활용하도록 프롬프트를 수정해 질 높은 개선팁 생성 가능

3. 과거 날짜 데이터 업로드 시 성장률 계산 로직 수정
- 최신 월 데이터 업로드 후 과거 월 데이터 업로드 시 성장률 갱신 문제 존재
- > updateMonthlyStats 메소드 로직을 수정해 다음 달 데이터가 존재하면 해당 월 성장률을 재계산하도록 재귀 호출 로직 추가

4. 오래된 데이터 삭제 로직 변경, 외래 키 옵션 추가
- 오래된 데이터(MonthlyStat) 삭제 기능 불안정
- > 외래 키 옵션 추가, 벌크 삭제 로직을 삭제할 엔티티 조회 후 삭제 방식으로 변경